### PR TITLE
Add support for "cartalyst/sentinel" Auth Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 Nice and easy way to handle revisions of your db.
 
-* Handles the revisions in **bulk** - one entry covers all the created/updated fields, what makes it really **easy to eg. compare 2 given versions** or get all the data changed during single action. 
+* Handles the revisions in **bulk** - one entry covers all the created/updated fields, what makes it really **easy to eg. compare 2 given versions** or get all the data changed during single action.
 
 
 ## Requirements
 
 * This package requires PHP 5.4+
-* Currently it works out of the box with Laravel5 + generic Illuminate Guard OR cartalyst/sentry 2
+* Currently it works out of the box with Laravel5 + generic Illuminate Guard OR cartalyst/sentry 2/sentinel 2
 
 
 ## Example display
@@ -62,6 +62,7 @@ return [
     | Supported options:
     |  - illuminate
     |  - sentry
+    |  - sentinel
     */
     'userprovider' => 'illuminate',
 
@@ -74,7 +75,7 @@ return [
     | By default:
     |
     |  - id for illuminate
-    |  - login field (email) for sentry
+    |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
 

--- a/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\Sofa\Revisionable\Adapters;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SentinelSpec extends ObjectBehavior
+{
+
+    /**
+     * @param  \Cartalyst\Sentinel\Sentinel $sentinel
+     */
+    function it_provides_user($sentinel)
+    {
+    	$this->beConstructedWith($sentinel);
+
+        $this->shouldImplement('\Sofa\Revisionable\UserProvider');
+    }
+
+    /**
+     * @param  \Cartalyst\Sentinel\Sentinel $sentinel
+     * @param  \Cartalyst\Sentinel\Users\UserInterface $user
+     */
+    function it_logs_login_field_by_default($sentinel, $user)
+    {
+        $sentinel->getUser()->shouldBeCalled()->willReturn($user);
+    	$this->beConstructedWith($sentinel);
+
+    	$user->getLogin()->shouldBeCalled()->willReturn('default_login');
+
+    	$this->getUser()->shouldReturn('default_login');
+    }
+
+    /**
+     * @param  \Cartalyst\Sentinel\Sentinel $sentinel
+     * @param  \Cartalyst\Sentinel\Users\UserInterface $user
+     */
+    function it_logs_custom_field_from_user_object_if_provided($sentinel, $user)
+    {
+    	$user->custom_field = 'john@doe.com';
+        $sentinel->getUser()->shouldBeCalled()->willReturn($user);
+
+    	$this->beConstructedWith($sentinel, 'custom_field');
+
+    	$this->getUser()->shouldReturn('john@doe.com');
+    }
+}

--- a/src/Adapters/Sentinel.php
+++ b/src/Adapters/Sentinel.php
@@ -1,0 +1,55 @@
+<?php namespace Sofa\Revisionable\Adapters;
+
+use Sofa\Revisionable\UserProvider;
+use Cartalyst\Sentinel\Sentinel as SentinelProvider;
+
+class Sentinel implements UserProvider
+{
+    /**
+     * Auth provider instance.
+     *
+     * @var \Cartalyst\Sentinel\Sentinel
+     */
+    protected $provider;
+
+    /**
+     * Field from the user to be saved as author of the action.
+     *
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * Create adapter instance for Sentinel.
+     *
+     * @param SentinelProvider $provider
+     * @param string $field
+     */
+    public function __construct(SentinelProvider $provider, $field = null)
+    {
+        $this->provider = $provider;
+        $this->field    = $field;
+    }
+
+    /**
+     * Get identifier of the currently logged in user.
+     *
+     * @return string|null
+     */
+    public function getUser()
+    {
+        return $this->getUserFieldValue();
+    }
+
+    /**
+     * Get value from the user to be saved as the author.
+     *
+     * @return string|null
+     */
+    protected function getUserFieldValue()
+    {
+        if ($user = $this->provider->getUser()) {
+            return ($field = $this->field) ? (string) $user->{$field} : $user->getLogin();
+        }
+    }
+}

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -70,6 +70,10 @@ class ServiceProvider extends BaseProvider
                 $this->bindSentryProvider();
                 break;
 
+            case 'sentinel':
+                $this->bindSentinelProvider();
+                break;
+
             default:
                 $this->bindGuardProvider();
         }
@@ -86,6 +90,20 @@ class ServiceProvider extends BaseProvider
             $field = $app['config']->get('sofa_revisionable.userfield');
 
             return new \Sofa\Revisionable\Adapters\Sentry($app['sentry'], $field);
+        });
+    }
+
+    /**
+     * Bind adapter for Sentinel to the IoC.
+     *
+     * @return void
+     */
+    protected function bindSentinelProvider()
+    {
+        $this->app->bindShared('revisionable.userprovider', function ($app) {
+            $field = $app['config']->get('sofa_revisionable.userfield');
+
+            return new \Sofa\Revisionable\Adapters\Sentinel($app['sentinel'], $field);
         });
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,7 @@ return [
     | Supported options:
     |  - illuminate
     |  - sentry
+    |  - sentinel
     */
     'userprovider' => 'illuminate',
 
@@ -24,7 +25,7 @@ return [
     | By default:
     |
     |  - id for illuminate
-    |  - login field (email) for sentry
+    |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
 


### PR DESCRIPTION
I intentionally didn't add "cartalyst/sentinel" package to the composer.json since it's a private package, those who need it & have access could require it.
