### PR TITLE
Add support for "cartalyst/sentinel" Auth Adabter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Disclaimer: This package is not a fork, nor does it use any piece of code from t
 ## Requirements
 
 * This package requires PHP 5.4+
-* Currently it works out of the box with Laravel4 + generic Auth guard OR cartalyst/sentry 2
+* Currently it works out of the box with Laravel4 + generic Auth guard OR cartalyst/sentry 2/sentinel 2
 
 ## Upgrade from 0.* to 0.2
 
@@ -156,6 +156,7 @@ return [
     | Supported options:
     |  - illuminate
     |  - sentry
+    |  - sentinel
     */
     'userprovider' => 'illuminate',
 
@@ -168,7 +169,7 @@ return [
     | By default:
     |
     |  - id for illuminate
-    |  - login field (email) for sentry
+    |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
 
@@ -308,6 +309,7 @@ return [
     | Supported options:
     |  - illuminate
     |  - sentry
+    |  - sentinel
     */
     'userprovider' => 'illuminate',
 
@@ -320,7 +322,7 @@ return [
     | By default:
     |
     |  - id for illuminate
-    |  - login field (email) for sentry
+    |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
 

--- a/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\Sofa\Revisionable\Adapters;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SentinelSpec extends ObjectBehavior
+{
+    function let($sentinel)
+    {
+		$sentinel->beADoubleOf('\Cartalyst\Sentinel\Sentinel');
+
+        $this->beConstructedWith($sentinel);
+    }
+
+    function it_provides_user()
+    {
+        $this->shouldImplement('\Sofa\Revisionable\UserProvider');
+    }
+}

--- a/src/Adapters/Sentinel.php
+++ b/src/Adapters/Sentinel.php
@@ -1,0 +1,57 @@
+<?php namespace Sofa\Revisionable\Adapters;
+
+use Sofa\Revisionable\UserProvider;
+use Cartalyst\Sentinel\Sentinel as SentinelProvider;
+
+class Sentinel implements UserProvider
+{
+    /**
+     * Auth provider instance.
+     *
+     * @var \Cartalyst\Sentinel\Sentinel
+     */
+    protected $provider;
+
+    /**
+     * Field from the user to be saved as author of the action.
+     *
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * Create adapter instance for Sentinel.
+     *
+     * @param SentinelProvider $provider
+     * @param string $field
+     */
+    public function __construct(SentinelProvider $provider, $field = null)
+    {
+        $this->provider = $provider;
+        $this->field    = $field;
+    }
+
+    /**
+     * Get identifier of the currently logged in user.
+     *
+     * @return string|null
+     */
+    public function getUser()
+    {
+        return $this->getUserFieldValue();
+    }
+
+    /**
+     * Get value from the user to be saved as the author.
+     *
+     * @return string|null
+     */
+    protected function getUserFieldValue()
+    {
+        if ($user = $this->provider->getUser())
+        {
+            return ($field = $this->field) ? (string) $user->{$field} : $user->getLogin();
+        }
+    }
+
+}

--- a/src/Laravel/FiveServiceProvider.php
+++ b/src/Laravel/FiveServiceProvider.php
@@ -72,6 +72,10 @@ class FiveServiceProvider extends ServiceProvider
                 $this->bindSentryProvider();
                 break;
 
+            case 'sentinel':
+                $this->bindSentinelProvider();
+                break;
+
             default:
                 $this->bindGuardProvider();
         }
@@ -86,6 +90,18 @@ class FiveServiceProvider extends ServiceProvider
     {
         $this->app->bindShared('revisionable.userprovider', function ($app) {
             return new \Sofa\Revisionable\Adapters\Sentry($app['sentry']);
+        });
+    }
+
+    /**
+     * Bind adapter for Sentinel to the IoC.
+     *
+     * @return void
+     */
+    protected function bindSentinelProvider()
+    {
+        $this->app->bindShared('revisionable.userprovider', function ($app) {
+            return new \Sofa\Revisionable\Adapters\Sentinel($app['sentinel']);
         });
     }
 

--- a/src/Laravel/FourServiceProvider.php
+++ b/src/Laravel/FourServiceProvider.php
@@ -60,6 +60,10 @@ class FourServiceProvider extends ServiceProvider
                 $this->bindSentryProvider();
                 break;
 
+            case 'sentinel':
+                $this->bindSentinelProvider();
+                break;
+
             default:
                 $this->bindGuardProvider();
         }
@@ -74,6 +78,18 @@ class FourServiceProvider extends ServiceProvider
     {
         $this->app->bindShared('revisionable.userprovider', function ($app) {
             return new \Sofa\Revisionable\Adapters\Sentry($app['sentry']);
+        });
+    }
+
+    /**
+     * Bind adapter for Sentinel to the IoC.
+     *
+     * @return void
+     */
+    protected function bindSentinelProvider()
+    {
+        $this->app->bindShared('revisionable.userprovider', function ($app) {
+            return new \Sofa\Revisionable\Adapters\Sentinel($app['sentinel']);
         });
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,7 @@ return [
     | Supported options:
     |  - illuminate
     |  - sentry
+    |  - sentinel
     */
     'userprovider' => 'illuminate',
 
@@ -24,7 +25,7 @@ return [
     | By default:
     |
     |  - id for illuminate
-    |  - login field (email) for sentry
+    |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
 


### PR DESCRIPTION
I intentionally didn't add "cartalyst/sentinel" package to the composer.json since it's a private package, those who need it & have access could require it.
