### PR TITLE
Add getUserModel to Revision model and make all checks pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
 
 script:
   - ./vendor/bin/phpspec run -v
-  - ./vendor/bin/phpcs src --standard=psr2
+  - ./vendor/bin/phpcs src --standard=PSR2LaravelMigrations.xml

--- a/PSR2LaravelMigrations.xml
+++ b/PSR2LaravelMigrations.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="PSR2LaravelMigrations">
+    <description>The PSR2LaravelMigrations coding standard.</description>
+    <arg name="tab-width" value="4"/>
+    <rule ref="PSR2">
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+    </rule>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "illuminate/database": "~5.0",
         "illuminate/auth": "~5.0",
         "cartalyst/sentry": "~2.0",
-        "tymon/jwt-auth": "^0.5.3"
+        "tymon/jwt-auth": "^0.5.3",
+        "cartalyst/sentinel": "^2.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,6 @@
         "cartalyst/sentinel": "^2.0"
     },
     "autoload": {
-        "classmap": [
-            "src/migrations"
-        ],
         "psr-4": {
             "Sofa\\Revisionable\\": "src"
         }

--- a/spec/Sofa/Revisionable/Adapters/GuardSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/GuardSpec.php
@@ -25,11 +25,11 @@ class GuardSpec extends ObjectBehavior
     function it_logs_auth_identifier_by_default($guard, $user)
     {
         $guard->user()->shouldBeCalled()->willReturn($user);
-    	$this->beConstructedWith($guard);
+        $this->beConstructedWith($guard);
 
-    	$user->getAuthIdentifier()->shouldBeCalled()->willReturn('default_id');
+        $user->getAuthIdentifier()->shouldBeCalled()->willReturn('default_id');
 
-    	$this->getUser()->shouldReturn('default_id');
+        $this->getUser()->shouldReturn('default_id');
     }
 
     /**
@@ -38,12 +38,12 @@ class GuardSpec extends ObjectBehavior
      */
     function it_logs_custom_field_from_user_object_if_provided($guard, $user)
     {
-    	$user->custom_field = 'john@doe.com';
+        $user->custom_field = 'john@doe.com';
         $guard->user()->shouldBeCalled()->willReturn($user);
 
-    	$this->beConstructedWith($guard, 'custom_field');
+        $this->beConstructedWith($guard, 'custom_field');
 
-    	$this->getUser()->shouldReturn('john@doe.com');
+        $this->getUser()->shouldReturn('john@doe.com');
     }
 
     /**

--- a/spec/Sofa/Revisionable/Adapters/GuardSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/GuardSpec.php
@@ -45,4 +45,32 @@ class GuardSpec extends ObjectBehavior
 
     	$this->getUser()->shouldReturn('john@doe.com');
     }
+
+    /**
+     * @param  \Illuminate\Auth\Guard $guard
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    function it_gets_the_active_user_model($guard, $user)
+    {
+        $guard->user()->shouldBeCalled()->willReturn($user);
+
+        $this->beConstructedWith($guard);
+
+        $this->getUserModel()->shouldReturn($user);
+    }
+
+    /**
+     * @param  \Illuminate\Auth\Guard $guard
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  \Illuminate\Contracts\Auth\UserProvider $provider
+     */
+    function it_gets_the_user_model_by_id($guard, $user, $provider)
+    {
+        $provider->retrieveById(1)->shouldBeCalled()->willReturn($user);
+        $guard->getProvider()->shouldBeCalled()->willReturn($provider);
+
+        $this->beConstructedWith($guard);
+
+        $this->getUserModel(1)->shouldReturn($user);
+    }
 }

--- a/spec/Sofa/Revisionable/Adapters/JwtAuthSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/JwtAuthSpec.php
@@ -47,4 +47,34 @@ class JwtAuthSpec extends ObjectBehavior
 
     	$this->getUser()->shouldReturn('john@doe.com');
     }
+
+    /**
+     * @param  \Tymon\JWTAuth\JWTAuth $guard
+     * @param  \Tymon\JWTAuth\Providers\User\EloquentUserAdapter $user
+     */
+    function it_gets_the_active_user_model($guard, $user)
+    {
+        $guard->parseToken()->shouldBeCalled()->willReturn($guard);
+        $guard->toUser()->shouldBeCalled()->willReturn($user);
+
+        $this->beConstructedWith($guard);
+
+        $this->getUserModel();
+    }
+
+    /**
+     * @param  \Tymon\JWTAuth\JWTAuth $guard
+     * @param  \Tymon\JWTAuth\Providers\User\EloquentUserAdapter $user
+     */
+    function it_gets_the_user_model_by_id($guard, $user)
+    {
+        $guard->toUser()->shouldBeCalled()->willReturn($user);
+        $guard->fromUser(Argument::type('object'))->shouldBeCalled()->willReturn($guard);
+
+        $guard->getIdentifier()->shouldBeCalled()->willReturn('id');
+
+        $this->beConstructedWith($guard);
+
+        $this->getUserModel(1);
+    }
 }

--- a/spec/Sofa/Revisionable/Adapters/JwtAuthSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/JwtAuthSpec.php
@@ -28,9 +28,9 @@ class JwtAuthSpec extends ObjectBehavior
         $guard->parseToken()->shouldBeCalled()->willReturn($guard);
         $guard->toUser()->shouldBeCalled()->willReturn($user);
 
-    	$guard->getIdentifier()->shouldBeCalled()->willReturn('id');
+        $guard->getIdentifier()->shouldBeCalled()->willReturn('id');
 
-    	$this->getUser()->shouldReturn('id');
+        $this->getUser()->shouldReturn('id');
     }
 
     /**
@@ -39,13 +39,13 @@ class JwtAuthSpec extends ObjectBehavior
      */
     function it_logs_custom_field_from_user_object_if_provided($guard, $user)
     {
-    	$user->custom_field = 'john@doe.com';
+        $user->custom_field = 'john@doe.com';
         $guard->parseToken()->shouldBeCalled()->willReturn($guard);
         $guard->toUser()->shouldBeCalled()->willReturn($user);
 
-    	$this->beConstructedWith($guard, 'custom_field');
+        $this->beConstructedWith($guard, 'custom_field');
 
-    	$this->getUser()->shouldReturn('john@doe.com');
+        $this->getUser()->shouldReturn('john@doe.com');
     }
 
     /**

--- a/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
@@ -13,7 +13,7 @@ class SentinelSpec extends ObjectBehavior
      */
     function it_provides_user($sentinel)
     {
-    	$this->beConstructedWith($sentinel);
+        $this->beConstructedWith($sentinel);
 
         $this->shouldImplement('\Sofa\Revisionable\UserProvider');
     }
@@ -25,11 +25,11 @@ class SentinelSpec extends ObjectBehavior
     function it_logs_login_field_by_default($sentinel, $user)
     {
         $sentinel->getUser()->shouldBeCalled()->willReturn($user);
-    	$this->beConstructedWith($sentinel);
+        $this->beConstructedWith($sentinel);
 
-    	$user->getUserLogin()->shouldBeCalled()->willReturn('default_login');
+        $user->getUserLogin()->shouldBeCalled()->willReturn('default_login');
 
-    	$this->getUser()->shouldReturn('default_login');
+        $this->getUser()->shouldReturn('default_login');
     }
 
     /**
@@ -38,12 +38,12 @@ class SentinelSpec extends ObjectBehavior
      */
     function it_logs_custom_field_from_user_object_if_provided($sentinel, $user)
     {
-    	$user->custom_field = 'john@doe.com';
+        $user->custom_field = 'john@doe.com';
         $sentinel->getUser()->shouldBeCalled()->willReturn($user);
 
-    	$this->beConstructedWith($sentinel, 'custom_field');
+        $this->beConstructedWith($sentinel, 'custom_field');
 
-    	$this->getUser()->shouldReturn('john@doe.com');
+        $this->getUser()->shouldReturn('john@doe.com');
     }
 
     /**

--- a/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
@@ -27,7 +27,7 @@ class SentinelSpec extends ObjectBehavior
         $sentinel->getUser()->shouldBeCalled()->willReturn($user);
     	$this->beConstructedWith($sentinel);
 
-    	$user->getLogin()->shouldBeCalled()->willReturn('default_login');
+    	$user->getUserLogin()->shouldBeCalled()->willReturn('default_login');
 
     	$this->getUser()->shouldReturn('default_login');
     }

--- a/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentinelSpec.php
@@ -45,4 +45,32 @@ class SentinelSpec extends ObjectBehavior
 
     	$this->getUser()->shouldReturn('john@doe.com');
     }
+
+    /**
+     * @param  \Cartalyst\Sentinel\Sentinel $sentinel
+     * @param  \Cartalyst\Sentinel\Users\UserInterface $user
+     */
+    function it_gets_the_active_user_model($sentinel, $user)
+    {
+        $sentinel->getUser()->shouldBeCalled()->willReturn($user);
+
+        $this->beConstructedWith($sentinel);
+
+        $this->getUserModel()->shouldReturn($user);
+    }
+
+    /**
+     * @param  \Cartalyst\Sentinel\Sentinel $sentinel
+     * @param  \Cartalyst\Sentinel\Users\UserInterface $user
+     * @param  \Cartalyst\Sentinel\Users\UserRepositoryInterface $users
+     */
+    function it_gets_the_user_model_by_id($sentinel, $user, $users)
+    {
+        $users->findByCredentials(Argument::type('array'))->shouldBeCalled()->willReturn($user);
+        $sentinel->getUserRepository()->shouldBeCalled()->willReturn($users);
+
+        $this->beConstructedWith($sentinel);
+
+        $this->getUserModel('john@doe.com')->shouldReturn($user);
+    }
 }

--- a/spec/Sofa/Revisionable/Adapters/SentrySpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentrySpec.php
@@ -7,14 +7,14 @@ use Prophecy\Argument;
 
 class SentrySpec extends ObjectBehavior
 {
-    
+
     /**
      * @param  \Cartalyst\Sentry\Sentry $sentry
      */
     function it_provides_user($sentry)
     {
     	$this->beConstructedWith($sentry);
-    	
+
         $this->shouldImplement('\Sofa\Revisionable\UserProvider');
     }
 
@@ -44,5 +44,33 @@ class SentrySpec extends ObjectBehavior
     	$this->beConstructedWith($sentry, 'custom_field');
 
     	$this->getUser()->shouldReturn('john@doe.com');
+    }
+
+    /**
+     * @param  \Cartalyst\Sentry\Sentry $sentry
+     * @param  \Cartalyst\Sentry\Users\UserInterface $user
+     */
+    function it_gets_the_active_user_model($sentry, $user)
+    {
+        $sentry->getUser()->shouldBeCalled()->willReturn($user);
+
+        $this->beConstructedWith($sentry);
+
+        $this->getUserModel()->shouldReturn($user);
+    }
+
+    /**
+     * @param  \Cartalyst\Sentry\Sentry $sentry
+     * @param  \Cartalyst\Sentry\Users\UserInterface $user
+     * @param  \Cartalyst\Sentry\Users\ProviderInterface $users
+     */
+    function it_gets_the_user_model_by_id($sentry, $user, $users)
+    {
+        $users->findByCredentials(Argument::type('array'))->shouldBeCalled()->willReturn($user);
+        $sentry->getUserProvider()->shouldBeCalled()->willReturn($users);
+
+        $this->beConstructedWith($sentry);
+
+        $this->getUserModel('john@doe.com')->shouldReturn($user);
     }
 }

--- a/spec/Sofa/Revisionable/Adapters/SentrySpec.php
+++ b/spec/Sofa/Revisionable/Adapters/SentrySpec.php
@@ -13,7 +13,7 @@ class SentrySpec extends ObjectBehavior
      */
     function it_provides_user($sentry)
     {
-    	$this->beConstructedWith($sentry);
+        $this->beConstructedWith($sentry);
 
         $this->shouldImplement('\Sofa\Revisionable\UserProvider');
     }
@@ -25,11 +25,11 @@ class SentrySpec extends ObjectBehavior
     function it_logs_login_field_by_default($sentry, $user)
     {
         $sentry->getUser()->shouldBeCalled()->willReturn($user);
-    	$this->beConstructedWith($sentry);
+        $this->beConstructedWith($sentry);
 
-    	$user->getLogin()->shouldBeCalled()->willReturn('default_login');
+        $user->getLogin()->shouldBeCalled()->willReturn('default_login');
 
-    	$this->getUser()->shouldReturn('default_login');
+        $this->getUser()->shouldReturn('default_login');
     }
 
     /**
@@ -38,12 +38,12 @@ class SentrySpec extends ObjectBehavior
      */
     function it_logs_custom_field_from_user_object_if_provided($sentry, $user)
     {
-    	$user->custom_field = 'john@doe.com';
+        $user->custom_field = 'john@doe.com';
         $sentry->getUser()->shouldBeCalled()->willReturn($user);
 
-    	$this->beConstructedWith($sentry, 'custom_field');
+        $this->beConstructedWith($sentry, 'custom_field');
 
-    	$this->getUser()->shouldReturn('john@doe.com');
+        $this->getUser()->shouldReturn('john@doe.com');
     }
 
     /**

--- a/src/Adapters/Guard.php
+++ b/src/Adapters/Guard.php
@@ -1,10 +1,13 @@
-<?php namespace Sofa\Revisionable\Adapters;
+<?php
+
+namespace Sofa\Revisionable\Adapters;
 
 use Sofa\Revisionable\UserProvider;
 use Illuminate\Auth\Guard as BaseGuard;
 
 class Guard implements UserProvider
 {
+
     /**
      * Auth provider instance.
      *
@@ -28,7 +31,7 @@ class Guard implements UserProvider
     public function __construct(BaseGuard $provider, $field = null)
     {
         $this->provider = $provider;
-        $this->field    = $field;
+        $this->field = $field;
     }
 
     /**
@@ -52,6 +55,7 @@ class Guard implements UserProvider
             return ($field = $this->field) ? (string) $user->{$field} : $user->getAuthIdentifier();
         }
     }
+
     /**
      * Return user model
      * @return object|array|null

--- a/src/Adapters/Guard.php
+++ b/src/Adapters/Guard.php
@@ -11,14 +11,14 @@ class Guard implements UserProvider
      * @var \Illuminate\Auth\Guard
      */
     protected $provider;
-    
+
     /**
      * Field from the user to be saved as author of the action.
      *
      * @var string
      */
     protected $field;
-    
+
     /**
      * Create adapter instance for Illuminate Guard.
      *
@@ -51,5 +51,13 @@ class Guard implements UserProvider
         if ($user = $this->provider->user()) {
             return ($field = $this->field) ? (string) $user->{$field} : $user->getAuthIdentifier();
         }
+    }
+    /**
+     * Return user model
+     * @return object|array|null
+     */
+    public function getUserModel($id = null)
+    {
+        return ($id) ? $this->provider->getProvider()->retrieveById($id) : $this->provider->user();
     }
 }

--- a/src/Adapters/JwtAuth.php
+++ b/src/Adapters/JwtAuth.php
@@ -54,4 +54,15 @@ class JwtAuth implements UserProvider
             return ($field = $this->field) ? (string)$user->{$field} : $this->provider->getIdentifier();
         }
     }
+
+    /**
+     * @return object|array|null
+     */
+    public function getUserModel($id = null){
+        if($id) {
+            return $this->provider->fromUser((object) [$this->provider->getIdentifier() => $id])->toUser();
+        } else {
+            return $this->provider->parseToken()->toUser();
+        }
+    }
 }

--- a/src/Adapters/JwtAuth.php
+++ b/src/Adapters/JwtAuth.php
@@ -1,5 +1,6 @@
-<?php namespace Sofa\Revisionable\Adapters;
+<?php
 
+namespace Sofa\Revisionable\Adapters;
 
 use Sofa\Revisionable\UserProvider;
 use Tymon\JWTAuth\JWTAuth as JWT;
@@ -51,15 +52,16 @@ class JwtAuth implements UserProvider
     protected function getUserFieldValue()
     {
         if ($user = $this->provider->parseToken()->toUser()) {
-            return ($field = $this->field) ? (string)$user->{$field} : $this->provider->getIdentifier();
+            return ($field = $this->field) ? (string) $user->{$field} : $this->provider->getIdentifier();
         }
     }
 
     /**
      * @return object|array|null
      */
-    public function getUserModel($id = null){
-        if($id) {
+    public function getUserModel($id = null)
+    {
+        if ($id) {
             return $this->provider->fromUser((object) [$this->provider->getIdentifier() => $id])->toUser();
         } else {
             return $this->provider->parseToken()->toUser();

--- a/src/Adapters/Sentinel.php
+++ b/src/Adapters/Sentinel.php
@@ -49,7 +49,7 @@ class Sentinel implements UserProvider
     protected function getUserFieldValue()
     {
         if ($user = $this->provider->getUser()) {
-            return ($field = $this->field) ? (string) $user->{$field} : $user->getLogin();
+            return ($field = $this->field) ? (string) $user->{$field} : $user->getUserLogin();
         }
     }
 }

--- a/src/Adapters/Sentinel.php
+++ b/src/Adapters/Sentinel.php
@@ -1,10 +1,13 @@
-<?php namespace Sofa\Revisionable\Adapters;
+<?php
+
+namespace Sofa\Revisionable\Adapters;
 
 use Sofa\Revisionable\UserProvider;
 use Cartalyst\Sentinel\Sentinel as SentinelProvider;
 
 class Sentinel implements UserProvider
 {
+
     /**
      * Auth provider instance.
      *
@@ -28,7 +31,7 @@ class Sentinel implements UserProvider
     public function __construct(SentinelProvider $provider, $field = null)
     {
         $this->provider = $provider;
-        $this->field    = $field;
+        $this->field = $field;
     }
 
     /**
@@ -56,7 +59,12 @@ class Sentinel implements UserProvider
     /**
      * @return object|array|null
      */
-    public function getUserModel($id = null){
-        return ($id) ? $this->provider->getUserRepository()->findByCredentials([$this->field => $id]) : $this->provider->getUser();
+    public function getUserModel($id = null)
+    {
+        return
+            ($id) ?
+                $this->provider->getUserRepository()->findByCredentials([$this->field => $id]) :
+                $this->provider->getUser()
+        ;
     }
 }

--- a/src/Adapters/Sentinel.php
+++ b/src/Adapters/Sentinel.php
@@ -52,4 +52,11 @@ class Sentinel implements UserProvider
             return ($field = $this->field) ? (string) $user->{$field} : $user->getUserLogin();
         }
     }
+
+    /**
+     * @return object|array|null
+     */
+    public function getUserModel($id = null){
+        return ($id) ? $this->provider->getUserRepository()->findByCredentials([$this->field => $id]) : $this->provider->getUser();
+    }
 }

--- a/src/Adapters/Sentry.php
+++ b/src/Adapters/Sentry.php
@@ -11,14 +11,14 @@ class Sentry implements UserProvider
      * @var \Cartalyst\Sentry\Sentry
      */
     protected $provider;
-    
+
     /**
      * Field from the user to be saved as author of the action.
      *
      * @var string
      */
     protected $field;
-    
+
     /**
      * Create adapter instance for Sentry.
      *
@@ -51,5 +51,12 @@ class Sentry implements UserProvider
         if ($user = $this->provider->getUser()) {
             return ($field = $this->field) ? (string) $user->{$field} : $user->getLogin();
         }
+    }
+
+    /**
+     * @return object|array|null
+     */
+    public function getUserModel($id = null){
+        return ($id) ? $this->provider->getUserProvider()->findByCredentials([$this->field => $id]) : $this->provider->getUser();
     }
 }

--- a/src/Adapters/Sentry.php
+++ b/src/Adapters/Sentry.php
@@ -1,10 +1,13 @@
-<?php namespace Sofa\Revisionable\Adapters;
+<?php
+
+namespace Sofa\Revisionable\Adapters;
 
 use Sofa\Revisionable\UserProvider;
 use Cartalyst\Sentry\Sentry as SentryProvider;
 
 class Sentry implements UserProvider
 {
+
     /**
      * Auth provider instance.
      *
@@ -28,7 +31,7 @@ class Sentry implements UserProvider
     public function __construct(SentryProvider $provider, $field = null)
     {
         $this->provider = $provider;
-        $this->field    = $field;
+        $this->field = $field;
     }
 
     /**
@@ -56,7 +59,12 @@ class Sentry implements UserProvider
     /**
      * @return object|array|null
      */
-    public function getUserModel($id = null){
-        return ($id) ? $this->provider->getUserProvider()->findByCredentials([$this->field => $id]) : $this->provider->getUser();
+    public function getUserModel($id = null)
+    {
+        return
+            ($id) ?
+                $this->provider->getUserProvider()->findByCredentials([$this->field => $id]) :
+                $this->provider->getUser()
+        ;
     }
 }

--- a/src/Laravel/DbLogger.php
+++ b/src/Laravel/DbLogger.php
@@ -6,6 +6,7 @@ use DateTime;
 
 class DbLogger implements Logger
 {
+
     /**
      * Custom database connection.
      *
@@ -36,18 +37,18 @@ class DbLogger implements Logger
     public function __construct(ConnectionInterface $connection, $table)
     {
         $this->defaultConnection = $connection;
-        $this->table             = $table;
+        $this->table = $table;
     }
 
     /**
      * Log data revisions in the db.
      *
-     * @param  string  $action
-     * @param  string  $table
-     * @param  int     $id
-     * @param  array   $old
-     * @param  array   $new
-     * @param  string  $user
+     * @param  string $action
+     * @param  string $table
+     * @param  int $id
+     * @param  array $old
+     * @param  array $new
+     * @param  string $user
      * @return void
      */
     public function revisionLog($action, $table, $id, array $old = [], array $new = [], $user = null)
@@ -89,7 +90,7 @@ class DbLogger implements Logger
     /**
      * Translate provided user to appropriate string.
      *
-     * @param  mixed  $user
+     * @param  mixed $user
      * @return string
      */
     protected function parseUser($user)
@@ -121,7 +122,7 @@ class DbLogger implements Logger
      * Get Server variable.
      *
      * @param  string $key
-     * @param  mixed  $default
+     * @param  mixed $default
      * @return string|array
      */
     protected function getFromServer($key, $default = null)

--- a/src/Laravel/Listener.php
+++ b/src/Laravel/Listener.php
@@ -6,6 +6,7 @@ use Sofa\Revisionable\Revisionable;
 
 class Listener implements ListenerInterface
 {
+
     /**
      * User provider instance.
      *
@@ -88,15 +89,15 @@ class Listener implements ListenerInterface
      */
     protected function log($action, Revisionable $revisioned)
     {
-        if (!$revisioned->isRevisioned()) {
+        if (! $revisioned->isRevisioned()) {
             return;
         }
 
         $table = $revisioned->getTable();
-        $id    = $revisioned->getKey();
-        $user  = $this->getCurrentUser();
-        $old   = [];
-        $new   = [];
+        $id = $revisioned->getKey();
+        $user = $this->getCurrentUser();
+        $old = [];
+        $new = [];
 
         switch ($action) {
             case 'created':

--- a/src/Laravel/Presenter.php
+++ b/src/Laravel/Presenter.php
@@ -6,6 +6,7 @@ use Sofa\Revisionable\Revisionable;
 
 class Presenter
 {
+
     /**
      * Revisionable fields labels.
      *
@@ -76,7 +77,7 @@ class Presenter
      */
     public function __construct(Revision $revision, Model $revisioned)
     {
-        $this->revision   = $revision;
+        $this->revision = $revision;
         $this->revisioned = $revisioned;
     }
 
@@ -147,7 +148,7 @@ class Presenter
     /**
      * Get pass through value using dot notation.
      *
-     * @param  mixed  $target
+     * @param  mixed $target
      * @param  string $key
      * @return mixed
      */
@@ -167,7 +168,7 @@ class Presenter
                 $target = null;
             }
 
-            if (!$target) {
+            if (! $target) {
                 return;
             }
         }
@@ -229,16 +230,16 @@ class Presenter
      */
     protected function getVersion($version)
     {
-        if (!$this->{$version.'Version'}) {
+        if (! $this->{$version . 'Version'}) {
             $revisioned = get_class($this->revisioned);
 
             $revision = new $revisioned;
             $revision->setRawAttributes($this->{$version});
 
-            $this->{$version.'Version'} = $revision;
+            $this->{$version . 'Version'} = $revision;
         }
 
-        return $this->{$version.'Version'};
+        return $this->{$version . 'Version'};
     }
 
     /**
@@ -265,7 +266,7 @@ class Presenter
         }
 
         throw new \InvalidArgumentException(
-            'Presenter::make accepts array, collection or single resource, '.gettype($revision).' given.'
+            'Presenter::make accepts array, collection or single resource, ' . gettype($revision) . ' given.'
         );
     }
 

--- a/src/Laravel/Revision.php
+++ b/src/Laravel/Revision.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class Revision extends Model
 {
+
     /**
      * The database table used by the model.
      *
@@ -116,12 +117,12 @@ class Revision extends Model
     /**
      * Set custom table name for the model.
      *
-     * @param  string  $table
+     * @param  string $table
      * @return void
      */
     public static function setCustomTable($table)
     {
-        if (!isset(static::$customTable)) {
+        if (! isset(static::$customTable)) {
             static::$customTable = $table;
         }
     }

--- a/src/Laravel/Revision.php
+++ b/src/Laravel/Revision.php
@@ -127,6 +127,15 @@ class Revision extends Model
     }
 
     /**
+     * Get user model from user provider
+     * @return mixed
+     */
+    public function getUserModel()
+    {
+        return app('revisionable.userprovider')->getUserModel($this->user);
+    }
+
+    /**
      * Handle dynamic method calls.
      *
      * @param  string $method

--- a/src/Laravel/RevisionableTrait.php
+++ b/src/Laravel/RevisionableTrait.php
@@ -23,6 +23,7 @@ use DateTime;
  */
 trait RevisionableTrait
 {
+
     /**
      * Revisionable Logger instance.
      *
@@ -57,7 +58,8 @@ trait RevisionableTrait
     public static function registerListeners()
     {
         foreach (static::getRevisionableEvents() as $event) {
-            static::{"register{$event}Listener"}();
+            static::{
+                "register{$event}Listener"}();
         }
     }
 
@@ -110,7 +112,7 @@ trait RevisionableTrait
      */
     public static function bootLogger()
     {
-        if (!static::$revisionableLogger) {
+        if (! static::$revisionableLogger) {
             static::setRevisionableLogger(App::make('revisionable.logger'));
         }
     }
@@ -188,7 +190,7 @@ trait RevisionableTrait
     /**
      * Stringify revisionable attributes.
      *
-     * @param  array  $attributes
+     * @param  array $attributes
      * @return array
      */
     protected function prepareAttributes(array $attributes)
@@ -203,7 +205,7 @@ trait RevisionableTrait
     /**
      * Get an array of revisionable attributes.
      *
-     * @param  array  $values
+     * @param  array $values
      * @return array
      */
     public function getRevisionableItems(array $values)
@@ -354,9 +356,9 @@ trait RevisionableTrait
         $presenter = $this->getRevisionPresenter();
 
         return (is_subclass_of($presenter, $this->getDefaultRevisionPresenter())
-                || $presenter == $this->getDefaultRevisionPresenter())
-                    ? $presenter::make($revision, $this)
-                    : $revision;
+            || $presenter == $this->getDefaultRevisionPresenter())
+            ? $presenter::make($revision, $this)
+            : $revision;
     }
 
     /**
@@ -368,7 +370,7 @@ trait RevisionableTrait
      */
     protected function loadRelationIfNecessary($relation)
     {
-        if (!array_key_exists($relation, $this->relations)) {
+        if (! array_key_exists($relation, $this->relations)) {
             $this->load($relation);
         }
     }
@@ -393,7 +395,7 @@ trait RevisionableTrait
      */
     public function getRevisionsCountAttribute()
     {
-        if (!array_key_exists('revisionsCount', $this->relations)) {
+        if (! array_key_exists('revisionsCount', $this->relations)) {
             $this->load('revisionsCount');
         }
 
@@ -491,7 +493,7 @@ trait RevisionableTrait
      */
     public function getRevisionPresenter()
     {
-        if (!isset($this->revisionPresenter)) {
+        if (! isset($this->revisionPresenter)) {
             return null;
         }
 

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -8,6 +8,7 @@ use ReflectionClass;
  */
 class ServiceProvider extends BaseProvider
 {
+
     /**
      * Indicates if loading of the provider is deferred.
      *
@@ -24,7 +25,7 @@ class ServiceProvider extends BaseProvider
     {
         $this->publishes([
             $this->guessPackagePath() . '/config/config.php' => config_path('sofa_revisionable.php'),
-            $this->guessPackagePath() . '/migrations/' => base_path('/database/migrations'),
+            $this->guessPackagePath() . '/migrations/'       => base_path('/database/migrations'),
         ]);
     }
 
@@ -187,6 +188,6 @@ class ServiceProvider extends BaseProvider
     {
         $path = (new ReflectionClass($this))->getFileName();
 
-        return realpath(dirname($path).'/../');
+        return realpath(dirname($path) . '/../');
     }
 }

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -2,6 +2,7 @@
 
 interface Listener
 {
+
     /**
      * @return null
      */

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,15 +2,16 @@
 
 interface Logger
 {
+
     /**
      * Log data revisions.
      *
-     * @param  string  $action
-     * @param  string  $table
+     * @param  string $action
+     * @param  string $table
      * @param  integer $id
-     * @param  array   $old
-     * @param  array   $new
-     * @param  mixed   $user
+     * @param  array $old
+     * @param  array $new
+     * @param  mixed $user
      *
      * @return  void
      */

--- a/src/Revisionable.php
+++ b/src/Revisionable.php
@@ -2,6 +2,7 @@
 
 interface Revisionable
 {
+
     /**
      * Boot Revisionable Logger.
      *
@@ -41,7 +42,7 @@ interface Revisionable
     /**
      * Get an array of revisionable attributes.
      *
-     * @param  array  $values
+     * @param  array $values
      * @return array
      */
     public function getRevisionableItems(array $values);

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -2,6 +2,7 @@
 
 interface UserProvider
 {
+
     /**
      * @return string|null
      */

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -6,4 +6,9 @@ interface UserProvider
      * @return string|null
      */
     public function getUser();
+
+    /**
+     * @return object|array|null
+     */
+    public function getUserModel($id);
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -16,8 +16,6 @@ return [
     |  - jwt-auth
     */
     'userprovider' => 'illuminate',
-
-
     /*
     |--------------------------------------------------------------------------
     | User field to be saved as the author of tracked action.
@@ -29,8 +27,6 @@ return [
     |  - login field (email) for sentry/sentinel
     */
     'userfield'    => null,
-
-
     /*
     |--------------------------------------------------------------------------
     | Table used for the revisions.

--- a/src/migrations/2015_03_05_000000_create_sofa_revisions_table.php
+++ b/src/migrations/2015_03_05_000000_create_sofa_revisions_table.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 
 class CreateSofaRevisionsTable extends Migration
 {
+
     /**
      * Revisions table.
      *

--- a/tests/Laravel/RevisionableTraitStub.php
+++ b/tests/Laravel/RevisionableTraitStub.php
@@ -23,22 +23,22 @@ class RevisionableTraitStub implements Revisionable
         return static::getEvents();
     }
 
-    public function registerCreatedListener()
+    public static function registerCreatedListener()
     {
         return static::registerCreated();
     }
 
-    public function registerUpdatedListener()
+    public static function registerUpdatedListener()
     {
         return static::registerUpdated();
     }
 
-    public function registerDeletedListener()
+    public static function registerDeletedListener()
     {
         return static::registerDeleted();
     }
 
-    public function registerRestoredListener()
+    public static function registerRestoredListener()
     {
         return static::registerRestored();
     }

--- a/tests/Laravel/UserProviderStub.php
+++ b/tests/Laravel/UserProviderStub.php
@@ -8,4 +8,8 @@ class UserProviderStub implements UserProvider
     {
 
     }
+
+    public function getUserModel($id = null){
+
+    }
 }


### PR DESCRIPTION
Added getUserModel to the Revision model to make it easier for getting access to the users information.

I fixed the tests that were existing to make them pass then added tests for each adapters new method.
